### PR TITLE
chore: add PR size score workflow and script

### DIFF
--- a/.github/workflows/pr_size_score.yml
+++ b/.github/workflows/pr_size_score.yml
@@ -1,0 +1,41 @@
+name: PR Size Score
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  score:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compute size score
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python scripts/compute_pr_size_score.py
+
+      - name: Commit metrics
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add metrics/pr_size_scores.jsonl
+          git commit -m "chore(metrics): add size score for #${{ github.event.pull_request.number }}" || exit 0
+          git push

--- a/scripts/compute_pr_size_score.py
+++ b/scripts/compute_pr_size_score.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+PRのサイズスコアを計算し、metrics/pr_size_scores.jsonlに追記する。
+GitHub Actionsから呼び出される。
+"""
+
+import json
+import math
+import os
+import subprocess
+
+
+def sh(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True).strip()
+
+
+repo = os.environ["REPO"]
+pr_number = os.environ["PR_NUMBER"]
+
+# GitHub APIからPR情報を取得
+pr = json.loads(sh(["gh", "api", f"repos/{repo}/pulls/{pr_number}"]))
+
+additions = int(pr["additions"])
+deletions = int(pr["deletions"])
+changed_files = int(pr["changed_files"])
+
+loc = additions + deletions
+files = max(changed_files, 1)
+
+# 規模スコア = log(loc + 1) * sqrt(files)
+size_score = math.log(loc + 1) * math.sqrt(files)
+
+record = {
+    "repo": repo,
+    "pr_number": int(pr_number),
+    "merged_at": pr["merged_at"],
+    "author": pr["user"]["login"],
+    "additions": additions,
+    "deletions": deletions,
+    "loc": loc,
+    "changed_files": changed_files,
+    "size_score": round(size_score, 6),
+}
+
+os.makedirs("metrics", exist_ok=True)
+with open("metrics/pr_size_scores.jsonl", "a", encoding="utf-8") as f:
+    f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+print("OK:", record)


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for PR size scoring
- Add Python script to compute PR size score

## Files
- `.github/workflows/pr_size_score.yml` - GitHub Actions workflow
- `scripts/compute_pr_size_score.py` - Score computation script

## Test plan
- [ ] Verify workflow triggers on PR events
- [ ] Verify score is computed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)