### PR TITLE
fix(docker): add @ds/icons package support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - demo_node_modules:/app/node_modules
       - demo_tokens_modules:/app/packages/tokens/node_modules
       - demo_ui_modules:/app/packages/ui/node_modules
+      - demo_icons_modules:/app/packages/icons/node_modules
       - demo_app_modules:/app/apps/demo-app/node_modules
       - demo_storybook_modules:/app/apps/storybook/node_modules
     environment:
@@ -27,6 +28,7 @@ services:
       - sb_node_modules:/app/node_modules
       - sb_tokens_modules:/app/packages/tokens/node_modules
       - sb_ui_modules:/app/packages/ui/node_modules
+      - sb_icons_modules:/app/packages/icons/node_modules
       - sb_app_modules:/app/apps/demo-app/node_modules
       - sb_storybook_modules:/app/apps/storybook/node_modules
     environment:
@@ -39,10 +41,12 @@ volumes:
   demo_node_modules:
   demo_tokens_modules:
   demo_ui_modules:
+  demo_icons_modules:
   demo_app_modules:
   demo_storybook_modules:
   sb_node_modules:
   sb_tokens_modules:
   sb_ui_modules:
+  sb_icons_modules:
   sb_app_modules:
   sb_storybook_modules:

--- a/docker/storybook/Dockerfile
+++ b/docker/storybook/Dockerfile
@@ -12,5 +12,5 @@ EXPOSE 6006
 # docker-compose.ymlで上書き可能
 ENV STORYBOOK_CLIENT_PORT=13004
 
-# Install dependencies and start storybook
-CMD ["sh", "-c", "pnpm install && cd apps/storybook && pnpm exec storybook dev -p 6006 --host 0.0.0.0 --no-open"]
+# Install dependencies, build packages, and start storybook
+CMD ["sh", "-c", "pnpm install && pnpm build && cd apps/storybook && pnpm exec storybook dev -p 6006 --host 0.0.0.0 --no-open"]


### PR DESCRIPTION
## Summary

- Add volume mounts for `packages/icons/node_modules` in docker-compose.yml
- Add `pnpm build` step to Dockerfile to build all packages before starting Storybook

## Problem

Docker環境でStorybookを起動すると、`@ds/icons`パッケージが見つからずエラーが発生していました：

```
Failed to fetch dynamically imported module: http://localhost:13004/src/stories/Icons.stories.tsx
```

## Cause

1. `docker-compose.yml`に`packages/icons`用のボリュームマウントがなかった
2. Dockerfileで`pnpm build`が実行されておらず、`@ds/icons`の`dist/`が生成されていなかった

## Test plan

- [ ] `docker compose down`
- [ ] `docker volume rm designsystem_sb_node_modules designsystem_sb_icons_modules` (optional)
- [ ] `docker compose --env-file .env.docker up storybook`
- [ ] Icons stories が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)