### PR TITLE
fix(ui): fix Container max-width and Sidebar height

### DIFF
--- a/packages/ui/dist/index.css
+++ b/packages/ui/dist/index.css
@@ -55,19 +55,19 @@
   padding-right: var(--spacing-lg);
 }
 .ds-container--sm {
-  max-width: 50%;
+  max-width: 640px;
 }
 .ds-container--md {
-  max-width: 65%;
+  max-width: 768px;
 }
 .ds-container--lg {
-  max-width: 80%;
+  max-width: 1024px;
 }
 .ds-container--xl {
-  max-width: 90%;
+  max-width: 1280px;
 }
 .ds-container--2xl {
-  max-width: 95%;
+  max-width: 1536px;
 }
 .ds-container--full {
   max-width: 100%;

--- a/packages/ui/dist/index.js
+++ b/packages/ui/dist/index.js
@@ -379,6 +379,7 @@ var Sidebar = ({
       className: `ds-sidebar ${className}`,
       style: {
         width,
+        height: "100%",
         flexShrink: 0,
         borderRight: "1px solid var(--color-border-default)",
         overflowY: "auto",

--- a/packages/ui/dist/styles.css
+++ b/packages/ui/dist/styles.css
@@ -500,26 +500,26 @@
   padding-right: var(--spacing-lg);
 }
 
-/* ===== Max Width Variants (比率ベース) ===== */
+/* ===== Max Width Variants (固定値) ===== */
 
 .ds-container--sm {
-  max-width: 50%;
+  max-width: 640px;
 }
 
 .ds-container--md {
-  max-width: 65%;
+  max-width: 768px;
 }
 
 .ds-container--lg {
-  max-width: 80%;
+  max-width: 1024px;
 }
 
 .ds-container--xl {
-  max-width: 90%;
+  max-width: 1280px;
 }
 
 .ds-container--2xl {
-  max-width: 95%;
+  max-width: 1536px;
 }
 
 .ds-container--full {

--- a/packages/ui/src/Container/Container.css
+++ b/packages/ui/src/Container/Container.css
@@ -15,26 +15,26 @@
   padding-right: var(--spacing-lg);
 }
 
-/* ===== Max Width Variants (比率ベース) ===== */
+/* ===== Max Width Variants (固定値) ===== */
 
 .ds-container--sm {
-  max-width: 50%;
+  max-width: 640px;
 }
 
 .ds-container--md {
-  max-width: 65%;
+  max-width: 768px;
 }
 
 .ds-container--lg {
-  max-width: 80%;
+  max-width: 1024px;
 }
 
 .ds-container--xl {
-  max-width: 90%;
+  max-width: 1280px;
 }
 
 .ds-container--2xl {
-  max-width: 95%;
+  max-width: 1536px;
 }
 
 .ds-container--full {

--- a/packages/ui/src/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/Sidebar/Sidebar.tsx
@@ -18,6 +18,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       className={`ds-sidebar ${className}`}
       style={{
         width,
+        height: '100%',
         flexShrink: 0,
         borderRight: '1px solid var(--color-border-default)',
         overflowY: 'auto',

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -2,6 +2,8 @@
 @import './Button/Button.css';
 @import './Input/Input.css';
 @import './Card/Card.css';
+@import './Heading/Heading.css';
+@import './Container/Container.css';
 
 /* Data Display */
 @import './Table/Table.css';


### PR DESCRIPTION
## Summary

- Fix Container component max-width values
- Fix Sidebar component height

## Changes

### Container
- Changed `max-width` from percentage to fixed pixel values
- Added missing `Container.css` and `Heading.css` imports in `styles.css`

| Size | Before | After |
|------|--------|-------|
| sm | 50% | 640px |
| md | 65% | 768px |
| lg | 80% | 1024px |
| xl | 90% | 1280px |
| 2xl | 95% | 1536px |

### Sidebar
- Added `height: 100%` to fill parent container height

## Test plan

- [ ] Storybook: Container sizes are visibly different
- [ ] Storybook: Sidebar fills full height of parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)