### PR TITLE
fix(tokens): improve dark theme surface-hover visibility

### DIFF
--- a/packages/tokens/src/modes/dark.css
+++ b/packages/tokens/src/modes/dark.css
@@ -9,7 +9,7 @@
   /* ===== Color: Background ===== */
   --color-bg-base: #0e1525;
   --color-bg-surface: #1c2333;
-  --color-bg-surface-hover: #252d3d;
+  --color-bg-surface-hover: #2d3748;
   --color-bg-muted: #2d3548;
   --color-bg-elevated: #343d52;
 


### PR DESCRIPTION
## Summary
- Adjusted `--color-bg-surface-hover` from `#252d3d` to `#2d3748` in the dark theme to improve hover visibility inside Card components
- The previous value had only ~9% RGB difference from the Card background (`--color-bg-surface: #1c2333`), making Table `hoverable` rows nearly invisible
- New value increases the per-channel gap to ~17, providing clear visual feedback

## Test plan
- [ ] Open Storybook in dark theme and verify Table hoverable story still looks correct
- [ ] Verify Button (secondary/ghost), Input, Sidebar, and Footer hover states remain visually consistent
- [ ] In the dashboard app, confirm "ずれ検知" table rows show visible hover effect inside Cards

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)