### PR TITLE
fix(ui): prevent isInvalid prop from leaking to DOM elements

### DIFF
--- a/apps/storybook/src/stories/Checkbox.stories.tsx
+++ b/apps/storybook/src/stories/Checkbox.stories.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from 'storybook/test'
 import { Checkbox } from '@ds/ui'
 
 const meta = {
@@ -97,4 +98,23 @@ export const MultipleOptions: Story = {
       <Checkbox disabled>Option D (disabled)</Checkbox>
     </div>
   ),
+}
+
+/* isInvalid / aria-invalid tests */
+export const InvalidAriaTest: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+      <Checkbox data-testid="invalid-checkbox" isInvalid>Must agree</Checkbox>
+      <Checkbox data-testid="valid-checkbox">Optional</Checkbox>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const invalidCheckbox = canvas.getByTestId('invalid-checkbox')
+    expect(invalidCheckbox).toHaveAttribute('aria-invalid', 'true')
+
+    const validCheckbox = canvas.getByTestId('valid-checkbox')
+    expect(validCheckbox).not.toHaveAttribute('aria-invalid')
+  },
 }

--- a/apps/storybook/src/stories/FormField.stories.tsx
+++ b/apps/storybook/src/stories/FormField.stories.tsx
@@ -57,7 +57,7 @@ export const WithError: Story = {
         required
         error="有効なメールアドレスを入力してください"
       >
-        <Input type="email" defaultValue="invalid-email" isInvalid />
+        <Input type="email" defaultValue="invalid-email" />
       </FormField>
     </div>
   ),
@@ -72,7 +72,7 @@ export const WithErrorAndDescription: Story = {
         description="8文字以上で、英数字を含めてください"
         error="パスワードが短すぎます"
       >
-        <Input type="password" defaultValue="123" isInvalid />
+        <Input type="password" defaultValue="123" />
       </FormField>
     </div>
   ),
@@ -206,5 +206,50 @@ export const InteractionTest: Story = {
     await userEvent.type(input, 'テスト入力')
 
     await expect(canvas.getByTestId('output')).toHaveTextContent('入力値: テスト入力')
+  },
+}
+
+export const InvalidStyleViaFormField: Story = {
+  render: () => (
+    <div style={{ width: '320px' }}>
+      <FormField
+        label="エラー付きフィールド"
+        error="エラーメッセージ"
+      >
+        <Input data-testid="error-input" />
+      </FormField>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByTestId('error-input')
+
+    // FormField passes aria-invalid, Input picks it up for styling
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+
+    // Verify the wrapper has the invalid CSS class
+    const wrapper = input.closest('.ds-input-wrapper')
+    expect(wrapper).toHaveClass('ds-input-wrapper--invalid')
+  },
+}
+
+export const NoErrorNoInvalid: Story = {
+  render: () => (
+    <div style={{ width: '320px' }}>
+      <FormField label="正常なフィールド">
+        <Input data-testid="normal-input" />
+      </FormField>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByTestId('normal-input')
+
+    // No error means no aria-invalid
+    expect(input).not.toHaveAttribute('aria-invalid')
+
+    // Wrapper should not have invalid class
+    const wrapper = input.closest('.ds-input-wrapper')
+    expect(wrapper).not.toHaveClass('ds-input-wrapper--invalid')
   },
 }

--- a/apps/storybook/src/stories/Input.stories.tsx
+++ b/apps/storybook/src/stories/Input.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from 'storybook/test'
 import { Input } from '@ds/ui'
 
 const meta = {
@@ -145,4 +146,23 @@ export const IconSizes: Story = {
       <Input size="lg" leftIcon={<SearchIcon />} placeholder="Large with icon" />
     </div>
   ),
+}
+
+/* isInvalid / aria-invalid tests */
+export const InvalidAriaTest: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', width: '300px' }}>
+      <Input data-testid="invalid-input" isInvalid placeholder="Invalid" />
+      <Input data-testid="valid-input" placeholder="Valid" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const invalidInput = canvas.getByTestId('invalid-input')
+    expect(invalidInput).toHaveAttribute('aria-invalid', 'true')
+
+    const validInput = canvas.getByTestId('valid-input')
+    expect(validInput).not.toHaveAttribute('aria-invalid')
+  },
 }

--- a/apps/storybook/src/stories/Select.stories.tsx
+++ b/apps/storybook/src/stories/Select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from 'storybook/test'
 import { Select, Option } from '@ds/ui'
 
 const meta = {
@@ -125,4 +126,27 @@ export const AllSizes: Story = {
       </Select>
     </div>
   ),
+}
+
+/* isInvalid / aria-invalid tests */
+export const InvalidAriaTest: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', width: '300px' }}>
+      <Select data-testid="invalid-select" isInvalid>
+        <Option value="1">Invalid</Option>
+      </Select>
+      <Select data-testid="valid-select">
+        <Option value="1">Valid</Option>
+      </Select>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const invalidSelect = canvas.getByTestId('invalid-select')
+    expect(invalidSelect).toHaveAttribute('aria-invalid', 'true')
+
+    const validSelect = canvas.getByTestId('valid-select')
+    expect(validSelect).not.toHaveAttribute('aria-invalid')
+  },
 }

--- a/packages/ui/dist/index.js
+++ b/packages/ui/dist/index.js
@@ -51,19 +51,21 @@ import { jsx as jsx2, jsxs as jsxs2 } from "react/jsx-runtime";
 var Input = forwardRef2(
   ({
     size = "md",
-    isInvalid = false,
+    isInvalid,
     disabled,
     leftIcon,
     rightIcon,
     className,
+    "aria-invalid": ariaInvalid,
     ...props
   }, ref) => {
+    const invalid = isInvalid ?? (ariaInvalid === true || ariaInvalid === "true");
     const hasLeftIcon = !!leftIcon;
     const hasRightIcon = !!rightIcon;
     return /* @__PURE__ */ jsxs2(
       "div",
       {
-        className: `ds-input-wrapper ds-input-wrapper--${size} ${isInvalid ? "ds-input-wrapper--invalid" : ""} ${disabled ? "ds-input-wrapper--disabled" : ""} ${className || ""}`,
+        className: `ds-input-wrapper ds-input-wrapper--${size} ${invalid ? "ds-input-wrapper--invalid" : ""} ${disabled ? "ds-input-wrapper--disabled" : ""} ${className || ""}`,
         children: [
           leftIcon && /* @__PURE__ */ jsx2("span", { className: "ds-input__icon ds-input__icon--left", children: leftIcon }),
           /* @__PURE__ */ jsx2(
@@ -72,7 +74,7 @@ var Input = forwardRef2(
               ref,
               className: `ds-input ${hasLeftIcon ? "ds-input--has-left-icon" : ""} ${hasRightIcon ? "ds-input--has-right-icon" : ""}`,
               disabled,
-              "aria-invalid": isInvalid,
+              "aria-invalid": invalid || void 0,
               ...props
             }
           ),
@@ -1052,17 +1054,19 @@ import { jsx as jsx15, jsxs as jsxs11 } from "react/jsx-runtime";
 var Select = forwardRef7(
   ({
     size = "md",
-    isInvalid = false,
+    isInvalid,
     disabled,
     placeholder,
     children,
     className,
+    "aria-invalid": ariaInvalid,
     ...props
   }, ref) => {
+    const invalid = isInvalid ?? (ariaInvalid === true || ariaInvalid === "true");
     const wrapperClasses = [
       "ds-select-wrapper",
       `ds-select-wrapper--${size}`,
-      isInvalid && "ds-select-wrapper--invalid",
+      invalid && "ds-select-wrapper--invalid",
       disabled && "ds-select-wrapper--disabled",
       className
     ].filter(Boolean).join(" ");
@@ -1073,7 +1077,7 @@ var Select = forwardRef7(
           ref,
           className: "ds-select",
           disabled,
-          "aria-invalid": isInvalid,
+          "aria-invalid": invalid || void 0,
           ...props,
           children: [
             placeholder && /* @__PURE__ */ jsx15("option", { value: "", disabled: true, children: placeholder }),
@@ -1098,15 +1102,17 @@ import { forwardRef as forwardRef8 } from "react";
 import { jsx as jsx16, jsxs as jsxs12 } from "react/jsx-runtime";
 var Checkbox = forwardRef8(
   ({
-    isInvalid = false,
+    isInvalid,
     disabled,
     children,
     className,
+    "aria-invalid": ariaInvalid,
     ...props
   }, ref) => {
+    const invalid = isInvalid ?? (ariaInvalid === true || ariaInvalid === "true");
     const wrapperClasses = [
       "ds-checkbox",
-      isInvalid && "ds-checkbox--invalid",
+      invalid && "ds-checkbox--invalid",
       disabled && "ds-checkbox--disabled",
       className
     ].filter(Boolean).join(" ");
@@ -1118,7 +1124,7 @@ var Checkbox = forwardRef8(
           type: "checkbox",
           className: "ds-checkbox__input",
           disabled,
-          "aria-invalid": isInvalid,
+          "aria-invalid": invalid || void 0,
           ...props
         }
       ),
@@ -1421,8 +1427,7 @@ function FormField({
     id: inputId,
     "aria-describedby": ariaDescribedBy,
     "aria-invalid": error ? true : void 0,
-    "aria-required": required || void 0,
-    isInvalid: error ? true : void 0
+    "aria-required": required || void 0
   }) : children;
   return /* @__PURE__ */ jsxs17("div", { className: `ds-form-field ${error ? "ds-form-field--error" : ""} ${className || ""}`, children: [
     /* @__PURE__ */ jsxs17("label", { htmlFor: inputId, className: "ds-form-field__label", children: [

--- a/packages/ui/src/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/Checkbox/Checkbox.tsx
@@ -11,17 +11,20 @@ export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (
     {
-      isInvalid = false,
+      isInvalid,
       disabled,
       children,
       className,
+      'aria-invalid': ariaInvalid,
       ...props
     },
     ref
   ) => {
+    const invalid = isInvalid ?? (ariaInvalid === true || ariaInvalid === 'true')
+
     const wrapperClasses = [
       'ds-checkbox',
-      isInvalid && 'ds-checkbox--invalid',
+      invalid && 'ds-checkbox--invalid',
       disabled && 'ds-checkbox--disabled',
       className,
     ]
@@ -35,7 +38,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           type="checkbox"
           className="ds-checkbox__input"
           disabled={disabled}
-          aria-invalid={isInvalid}
+          aria-invalid={invalid || undefined}
           {...props}
         />
         <span className="ds-checkbox__box" aria-hidden="true">

--- a/packages/ui/src/Input/Input.tsx
+++ b/packages/ui/src/Input/Input.tsx
@@ -17,21 +17,23 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
       size = 'md',
-      isInvalid = false,
+      isInvalid,
       disabled,
       leftIcon,
       rightIcon,
       className,
+      'aria-invalid': ariaInvalid,
       ...props
     },
     ref
   ) => {
+    const invalid = isInvalid ?? (ariaInvalid === true || ariaInvalid === 'true')
     const hasLeftIcon = !!leftIcon
     const hasRightIcon = !!rightIcon
 
     return (
       <div
-        className={`ds-input-wrapper ds-input-wrapper--${size} ${isInvalid ? 'ds-input-wrapper--invalid' : ''} ${disabled ? 'ds-input-wrapper--disabled' : ''} ${className || ''}`}
+        className={`ds-input-wrapper ds-input-wrapper--${size} ${invalid ? 'ds-input-wrapper--invalid' : ''} ${disabled ? 'ds-input-wrapper--disabled' : ''} ${className || ''}`}
       >
         {leftIcon && (
           <span className="ds-input__icon ds-input__icon--left">{leftIcon}</span>
@@ -40,7 +42,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           ref={ref}
           className={`ds-input ${hasLeftIcon ? 'ds-input--has-left-icon' : ''} ${hasRightIcon ? 'ds-input--has-right-icon' : ''}`}
           disabled={disabled}
-          aria-invalid={isInvalid}
+          aria-invalid={invalid || undefined}
           {...props}
         />
         {rightIcon && (

--- a/packages/ui/src/Select/Select.tsx
+++ b/packages/ui/src/Select/Select.tsx
@@ -18,19 +18,22 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   (
     {
       size = 'md',
-      isInvalid = false,
+      isInvalid,
       disabled,
       placeholder,
       children,
       className,
+      'aria-invalid': ariaInvalid,
       ...props
     },
     ref
   ) => {
+    const invalid = isInvalid ?? (ariaInvalid === true || ariaInvalid === 'true')
+
     const wrapperClasses = [
       'ds-select-wrapper',
       `ds-select-wrapper--${size}`,
-      isInvalid && 'ds-select-wrapper--invalid',
+      invalid && 'ds-select-wrapper--invalid',
       disabled && 'ds-select-wrapper--disabled',
       className,
     ]
@@ -43,7 +46,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           ref={ref}
           className="ds-select"
           disabled={disabled}
-          aria-invalid={isInvalid}
+          aria-invalid={invalid || undefined}
           {...props}
         >
           {placeholder && (

--- a/packages/ui/src/patterns/FormField/FormField.tsx
+++ b/packages/ui/src/patterns/FormField/FormField.tsx
@@ -42,7 +42,6 @@ export function FormField({
         'aria-describedby': ariaDescribedBy,
         'aria-invalid': error ? true : undefined,
         'aria-required': required || undefined,
-        isInvalid: error ? true : undefined,
       })
     : children
 


### PR DESCRIPTION
## Summary
- Remove `isInvalid` from FormField's `cloneElement` call to prevent the prop from leaking to DOM elements
- Update Input, Select, Checkbox to derive invalid state from `aria-invalid` when `isInvalid` is not explicitly set (e.g. when wrapped in FormField)
- Only render `aria-invalid` attribute on DOM elements when actually invalid (omit when false)

## Test plan
- [ ] Verify no React warnings about `isInvalid` prop on DOM elements
- [ ] Verify `isInvalid={true}` sets `aria-invalid="true"` on Input, Select, Checkbox
- [ ] Verify `aria-invalid` is absent when not invalid
- [ ] Verify FormField `error` prop correctly drives invalid styling via `aria-invalid`
- [ ] Verify error border styling (`--invalid` CSS class) still applies correctly
- [ ] Run Storybook interaction tests (`InvalidAriaTest`, `InvalidStyleViaFormField`, `NoErrorNoInvalid`)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)